### PR TITLE
Remove obsolete entry for XboxGameCallableUI from Bloatware.csv

### DIFF
--- a/Files/Bloatware.csv
+++ b/Files/Bloatware.csv
@@ -34,7 +34,6 @@ Name,Type
 "AD2F1837.HPSupportAssistant","Appx"
 "AD2F1837.HPEasyClean","Appx"
 "RealtekSemiconductorCorp.HPAudioControl","Appx"
-"XboxGameCallableUI","Appx"
 "Xbox","Appx"
 "XboxApp","Appx"
 "XboxGameOverlay","Appx"


### PR DESCRIPTION
The entry for Microsoft.XboxGameCallableUI has been removed from the Bloatware.csv file to address the issue of failed removal of the Appx package.

Fixes #11