### PR TITLE
Prioritize Set-PowerCFG.ps1 module loading

### DIFF
--- a/Stage2.ps1
+++ b/Stage2.ps1
@@ -17,12 +17,12 @@ Unregister-ScheduledTask -TaskName "Run_Stage2" -Confirm:$false
 
 Import-Module "C:\Temp\Preconfig\Powershell modules\Exit-Start-Menu.ps1"
 
+Import-Module "C:\Temp\Preconfig\Powershell modules\Set-PowerCFG.ps1"
 Import-Module "C:\Temp\Preconfig\Powershell modules\Set-Correct-Time.ps1"
 Import-Module "C:\Temp\Preconfig\Powershell modules\Set-DutchSettings.ps1"
 Import-Module "C:\Temp\Preconfig\Powershell modules\Set-UAC.ps1"
 Import-Module "C:\Temp\Preconfig\Powershell modules\Set-RegistryKeys.ps1"
 Import-Module "C:\Temp\Preconfig\Powershell modules\CtrlAltDelFix-V2.ps1"
-Import-Module "C:\Temp\Preconfig\Powershell modules\Set-PowerCFG.ps1"
 Import-Module "C:\Temp\Preconfig\Powershell modules\Remove-DefaultUser0.ps1"
 Import-Module "C:\Temp\Preconfig\Powershell modules\Winget-Adobe-Install.ps1"
 


### PR DESCRIPTION
Reordered module imports in Stage2.ps1 to ensure Set-PowerCFG.ps1 is loaded first. This change addresses the issue of PCs attempting to download the Dutch language pack and entering sleep mode before completion.

Fixes #17